### PR TITLE
Add ConvertQTIPackageAsync method and integrate it

### DIFF
--- a/Contracts/Services/ICreateQTIProcessorService.cs
+++ b/Contracts/Services/ICreateQTIProcessorService.cs
@@ -12,4 +12,5 @@ public interface ICreateQTIProcessorService
 {
     public Task<QTITest> PreProcessAsync(QTITestCreationDTO test);
     public Task<QTITest> PostProcessAsync(QTITest test);
+    public Task<String> ConvertQTIPackageAsync(string Base64Package);
 }

--- a/Service/CreateQTIProcessorService.cs
+++ b/Service/CreateQTIProcessorService.cs
@@ -95,7 +95,7 @@ public class CreateQTIProcessorService : ICreateQTIProcessorService
 
     //}
 
-    private async Task<String> ConvertQTIPackageAsync(string Base64Package)
+    public async Task<String> ConvertQTIPackageAsync(string Base64Package)
     {
         var requestContent = new StringContent(JsonSerializer.Serialize(new { zipFile = Base64Package }), Encoding.UTF8, "application/json");
         HttpResponseMessage response;


### PR DESCRIPTION
- Updated ICreateQTIProcessorService interface to include ConvertQTIPackageAsync method.
- Implemented ConvertQTIPackageAsync in CreateQTIProcessorService to handle Base64 encoded packages.
- Added logic in QTITestAdminService to call ConvertQTIPackageAsync when updating packagebase64 property.